### PR TITLE
Handle HTTP status

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ function BinaryXHR(url, cb) {
   xhr.open("GET", url, true)
   xhr.onreadystatechange = function () {
     if (self.xhr.readyState === 4) {
-      if (self.xhr.response && self.xhr.response.byteLength > 0) {
+      if (self.xhr.status !== 200) {
+        cb(self.xhr.status, self.xhr.response);
+      } else if (self.xhr.response && self.xhr.response.byteLength > 0) {
         cb(false, self.xhr.response)
       } else {
         if (self.xhr.response && self.xhr.response.byteLength === 0) return cb('response length 0')


### PR DESCRIPTION
If the server returns a non-200 status code (for example 404), currently binary-xhr will pass through the response content (for example "not found") through to the callback exactly as if it was retrieved without error.

This PR simply passes the status code in the 'err' parameter in the callback if not 200 OK, so applications can detect & handle the error accordingly.
