### PR TITLE
Fix for Firefox compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ function BinaryXHR(url, cb) {
   var self = this
   var xhr = new XMLHttpRequest()
   this.xhr = xhr
-  xhr.responseType = 'arraybuffer'
   xhr.open("GET", url, true)
+  xhr.responseType = 'arraybuffer'
   xhr.onreadystatechange = function () {
     if (self.xhr.readyState === 4) {
       if (self.xhr.response && self.xhr.response.byteLength > 0) {


### PR DESCRIPTION
Setting responseType before open() fails on Firefox with:

9 InvalidStateError: An attempt was made to use an object that is not,
or is no longer, usable
