### PR TITLE
remove unused inherits module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var inherits = require('inherits')
-
 module.exports = function(url, cb) {
   return new BinaryXHR(url, cb)
 }
@@ -24,3 +22,4 @@ function BinaryXHR(url, cb) {
   }
   xhr.send(null)
 }
+


### PR DESCRIPTION
I am building a secure web boot loader experiment, (like hyperboot or slugboot)
and need to have a minimal dependencies,
for ease of auditing, and also so that the need to update code is absolutely minimal,
so I'd like to remove this unneeded dependency.

Also, I notice that the errors are strings, not proper errors, shall we fix that?
